### PR TITLE
Immer patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,29 @@ _Which of these would you rather write?_
 
 `use-methods` is built on [`immer`](https://github.com/mweststrate/immer), which allows you to write your methods in an imperative, mutating style, even though the actual state managed behind the scenes is immutable. You can also return entirely new states from your methods where it's more convenient to do so (as in the `reset` example above).
 
+If you would like to use the [patches](https://github.com/immerjs/immer#patches) functionality from immer,
+you can attach a callback to the `methods` function passed to `use-methods`. The callback will be fed the
+patches applied to the state. For example: 
+
+```ts
+const patchList: any[] = [];
+const inverseList: any[] = [];
+
+const methods = (state: State) => ({
+  increment() {
+    state.count++;
+  },
+  decrement() {
+    state.count--;
+  }
+});
+
+addPatchCallback(methods, (patches, inversePatches) => {
+  patchList.push(...patches);
+  inverseList.push(...inversePatches);
+});
+```
+
 ## Memoization
 
 Like the `dispatch` method returned from `useReducer`, the callbacks returned from `useMethods` aren't recreated on each render, so they will not be the cause of needless re-rendering if passed as bare props to `React.memo`ized subcomponents. Save your `useCallback`s for functions that don't map exactly to an existing callback! In fact, the entire `callbacks` object (as in `[state, callbacks]`) is memoized, so you can use this to your deps array as well:

--- a/README.md
+++ b/README.md
@@ -72,26 +72,30 @@ _Which of these would you rather write?_
 `use-methods` is built on [`immer`](https://github.com/mweststrate/immer), which allows you to write your methods in an imperative, mutating style, even though the actual state managed behind the scenes is immutable. You can also return entirely new states from your methods where it's more convenient to do so (as in the `reset` example above).
 
 If you would like to use the [patches](https://github.com/immerjs/immer#patches) functionality from immer,
-you can attach a callback to the `methods` function passed to `use-methods`. The callback will be fed the
-patches applied to the state. For example: 
+you can pass an object to `useMethods` that contains the `methods` property and a `patchCallback`
+property.  The callback will be fed the patches applied to the state. For example: 
 
 ```ts
 const patchList: any[] = [];
 const inverseList: any[] = [];
 
-const methods = (state: State) => ({
-  increment() {
-    state.count++;
-  },
-  decrement() {
-    state.count--;
+const methodsObject = {
+  methods: (state: State) => ({
+    increment() {
+      state.count++;
+    },
+    decrement() {
+      state.count--;
+    }
+  }),
+  patchCallback: (patches: Patch[], inversePatches: Patch[]) => {
+    patchList.push(...patches);
+    inverseList.push(...inversePatches);
   }
-});
+};
 
-addPatchCallback(methods, (patches, inversePatches) => {
-  patchList.push(...patches);
-  inverseList.push(...inversePatches);
-});
+// ... and in the component
+const [state, { increment, decrement }] = useMethods(methodsObject, initialState);
 ```
 
 ## Memoization

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,23 +13,32 @@ export type CallbacksFor<M extends Methods> = M extends Methods<any, infer R>
     }
   : never;
 
-export type Methods<S = any, R extends MethodRecordBase<S> = any> = (state: S) => R;
+export type MethodsFn<S = any, R extends MethodRecordBase<S> = any> = (state: S) => R;
+
+export type MethodsObject<S = any, R extends MethodRecordBase<S> = any> = {
+  methods: MethodsFn<S, R>;
+  patchCallback?: PatchListener;
+};
+
+export type Methods<S = any, R extends MethodRecordBase<S> = any> =
+  | MethodsFn<S, R>
+  | MethodsObject<S, R>;
+
+function isMethodsFn<S = any, R extends MethodRecordBase<S> = any>(
+  methods: Methods<S, R>,
+): methods is MethodsFn<S, R> {
+  return typeof methods === 'function';
+}
+function isMethodsObject<S = any, R extends MethodRecordBase<S> = any>(
+  methods: Methods<S, R>,
+): methods is MethodsObject<S, R> {
+  return typeof methods === 'object';
+}
 
 export type MethodRecordBase<S = any> = Record<
   string,
   (...args: any[]) => S extends object ? S | void : S
 >;
-
-export const MethodsSymbol = {
-  patch: Symbol('patch'),
-};
-
-export function addPatchCallback<S = any, R extends MethodRecordBase<S> = any>(
-  methods: Methods<S, R>,
-  callback: PatchListener,
-): void {
-  (methods as any)[MethodsSymbol.patch] = callback;
-}
 
 export type ActionUnion<R extends MethodRecordBase> = {
   [T in keyof R]: { type: T; payload: Parameters<R[T]> }
@@ -51,20 +60,38 @@ export default function useMethods<S, R extends MethodRecordBase<S>>(
   initialState: any,
   initializer?: any,
 ): StateAndCallbacksFor<Methods<S, R>> {
-  const reducer = useMemo<Reducer<S, ActionUnion<R>>>(() => {
-    const patchMethod = (methods as any)[MethodsSymbol.patch] as PatchListener;
-    return (state: S, action: ActionUnion<R>) => {
-      return (produce as any)(
-        state,
-        (draft: S) => {
-          return methods(draft)[action.type](...action.payload);
+  const [reducer, methodsFn] = useMemo<[Reducer<S, ActionUnion<R>>, MethodsFn<S, R>]>(() => {
+    if (isMethodsFn(methods)) {
+      return [
+        (state: S, action: ActionUnion<R>) => {
+          return (produce as any)(state, (draft: S) => {
+            return methods(draft)[action.type](...action.payload);
+          });
         },
-        patchMethod,
-      );
-    };
+        methods,
+      ];
+    }
+
+    if (isMethodsObject(methods)) {
+      const { methods: methodsFn, patchCallback } = methods;
+      return [
+        (state: S, action: ActionUnion<R>) => {
+          return (produce as any)(
+            state,
+            (draft: S) => {
+              return methodsFn(draft)[action.type](...action.payload);
+            },
+            patchCallback,
+          );
+        },
+        methodsFn,
+      ];
+    }
+
+    throw new Error('Invalid methods argument.');
   }, [methods]);
   const [state, dispatch] = useReducer(reducer, initialState, initializer);
-  const actionTypes: ActionUnion<R>['type'][] = Object.keys(methods(state));
+  const actionTypes: ActionUnion<R>['type'][] = Object.keys(methodsFn(state));
   const callbacks = useMemo(
     () =>
       actionTypes.reduce(
@@ -72,7 +99,7 @@ export default function useMethods<S, R extends MethodRecordBase<S>>(
           accum[type] = (...payload) => dispatch({ type, payload } as ActionUnion<R>);
           return accum;
         },
-        {} as CallbacksFor<typeof methods>,
+        {} as CallbacksFor<typeof methodsFn>,
       ),
     actionTypes,
   );

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -1,8 +1,8 @@
-import useMethods, {addPatchCallback} from '../src';
+import useMethods from '../src';
 import React, { useLayoutEffect, useReducer, useMemo } from 'react';
 import { cleanup, render, fireEvent, RenderResult } from 'react-testing-library';
 import Todos from './Todos';
-import produce from 'immer';
+import { Patch } from 'immer';
 
 afterEach(cleanup);
 
@@ -205,23 +205,25 @@ it('will provide patches', () => {
   const patchList: any[] = [];
   const inverseList: any[] = [];
 
-  const methods = (state: State) => ({
-    increment() {
-      state.count++;
-    },
-    decrement() {
-      state.count--;
+  const methodsObject = {
+    methods: (state: State) => ({
+      increment() {
+        state.count++;
+      },
+      decrement() {
+        state.count--;
+      }
+    }),
+    patchCallback: (patches: Patch[], inversePatches: Patch[]) => {
+      patchList.push(...patches);
+      inverseList.push(...inversePatches);
     }
-  });
-  addPatchCallback(methods, (patches, inversePatches) => {
-    patchList.push(...patches);
-    inverseList.push(...inversePatches);
-  });
+  };
 
   const testId = 'counter-testid';
 
   function Counter() {
-    const [state, { increment, decrement }] = useMethods(methods, initialState);
+    const [state, { increment, decrement }] = useMethods(methodsObject, initialState);
     return (
       <>
         Count: <span data-testid={testId}>{state.count}</span>


### PR DESCRIPTION
Adds functionality to use the [immer patches](https://github.com/immerjs/immer#patches) functionality with `useMethods`.

Fixes #12 