### PR TITLE
Expose immer helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import produce, { PatchListener } from 'immer';
 import { Reducer, useMemo, useReducer } from 'react';
 
+export { isDraft, isDraftable, nothing, original, setAutoFreeze, setUseProxies } from 'immer';
+
 export type StateAndCallbacksFor<M extends MethodsOrOptions> = [StateFor<M>, CallbacksFor<M>];
 
 export type StateFor<M extends MethodsOrOptions> = M extends MethodsOrOptions<infer S, any>

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -1,6 +1,6 @@
 import { HookResult, renderHook, act } from '@testing-library/react-hooks';
 import { Patch } from 'immer';
-import useMethods from '../src';
+import useMethods, { isDraft, isDraftable, nothing, original, setAutoFreeze, setUseProxies } from '../src';
 import useTodos, { Todos } from './useTodos';
 
 describe('todos example', () => {
@@ -79,6 +79,15 @@ describe('todos example', () => {
       expect($.current.todos).toHaveLength(1);
     });
   });
+});
+
+it('exports immer helpers', () => {
+  expect(typeof isDraft).toBe('function');
+  expect(typeof isDraftable).toBe('function');
+  expect(typeof nothing).toBe('symbol');
+  expect(typeof original).toBe('function');
+  expect(typeof setAutoFreeze).toBe('function');
+  expect(typeof setUseProxies).toBe('function');
 });
 
 it('avoids invoking methods more than necessary', () => {


### PR DESCRIPTION
Immer has multiple helper functions for working with drafts. Many of these are at least version dependant, so it would be good to expose them through `useMethods`. For example, `isDraft` from immer 6.0.8 (currently the latest version) will return `false` for drafts created by `useMethods`.

There are quite a few more methods exported by `immer`. I don't think it's a good idea to re-export everything however, as e.g. `produce` would be better imported straight from `immer`.

On a side note, I had to disable prettier in order to prevent changes to unrelated parts of the code.