### PR TITLE
Immer updated to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "dependencies": {
     "@types/react": "^16.9.2",
-    "immer": "^4.0.0"
+    "immer": "^7.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
-import produce, { PatchListener } from 'immer';
+import produce, { PatchListener, enableAllPlugins } from 'immer';
 import { Reducer, useMemo, useReducer } from 'react';
+
+enableAllPlugins();
 
 export type StateAndCallbacksFor<M extends MethodsOrOptions> = [StateFor<M>, CallbacksFor<M>];
 


### PR DESCRIPTION
I had to update `immer` to v6+ in our app in order to get around this issue https://github.com/immerjs/immer/issues/577 that was plaguing us in some browsers, notably Firefox on Android and Legacy Edge (v44). Figured I may as well open a pull request. It seems to be working well for us, and the tests succeed.
